### PR TITLE
Add: 簡単なレシピページの作成と全体ページのレイアウト調整をしました

### DIFF
--- a/app/controllers/making_pancakes_controller.rb
+++ b/app/controllers/making_pancakes_controller.rb
@@ -1,0 +1,6 @@
+class MakingPancakesController < ApplicationController
+  def index
+  end
+  def simple_recipe
+  end
+end

--- a/app/helpers/making_pancakes_helper.rb
+++ b/app/helpers/making_pancakes_helper.rb
@@ -1,0 +1,2 @@
+module MakingPancakesHelper
+end

--- a/app/views/making_pancakes/index.html.slim
+++ b/app/views/making_pancakes/index.html.slim
@@ -3,13 +3,13 @@ body.bg-secondary.p-5
         .row.m-5
             .text-center.text-white
                 .h1
-                    | マイページメニュー
+                    |パンケーキを作る
         .row
             div.btn.btn-secondary.btn-sm.text-uppercase.mb-5
-                = link_to 'パンケーキ作成', making_pancakes_index_path
+                | カメラ起動
         .row
             div.btn.btn-secondary.btn-sm.text-uppercase.mb-5
-                | マイレシピ
+                = link_to '簡単なレシピを見る', making_pancakes_simple_recipe_path
         .row
             div.btn.btn-secondary.btn-sm.text-uppercase.mb-5
-                = link_to 'ホームに戻る', root_path
+                = link_to 'マイページに戻る', my_page_menus_index_path

--- a/app/views/making_pancakes/simple_recipe.html.slim
+++ b/app/views/making_pancakes/simple_recipe.html.slim
@@ -1,0 +1,40 @@
+body.bg-secondary.p-5
+    .container
+        .row.m-5
+            .text-center.text-white
+                .h1
+                    | シンプルなレシピ
+            .text-center.text-white
+                .h3.m-1
+                    | ~材料~
+            .text-center.text-white
+                | たまご　１個
+            .text-center.text-white
+                | 砂糖　30グラム
+            .text-center.text-white
+                | 牛乳　100グラム
+            .text-center.text-white
+                | 小麦粉　100グラム
+            .text-center.text-white
+                |　ベーキングパウダー　5グラム
+        .row.m-5
+            .text-center.text-white
+                .h3.m-1
+                    | ~作り方~
+            .text-center.text-white.m-2
+                | ボールに材料を入れて混ぜる
+            .text-center.text-white.m-2
+                | フライパンを弱火より少し強い火で熱する
+            .row.m-2
+                .text-center.text-white
+                    |　フライパンに油をしく
+                .text-center.text-white
+                    | （テフロン加工等くっつきにくいものなら油はいらない）
+            .text-center.text-white.m-2
+                | ぶつぶつがある程度出てきたらひっくり返す
+            .text-center.text-white.m-2
+                |　裏面を2分ぐらい焼いたら出来上がり
+        .container.text-white.mt-5
+            .row
+                div.btn.btn-secondary.btn-sm.text-uppercase.mb-5
+                    = link_to 'Back', making_pancakes_index_path

--- a/app/views/partials/_navbar.html.slim
+++ b/app/views/partials/_navbar.html.slim
@@ -9,12 +9,17 @@ nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav"
         div class="collapse navbar-collapse" id="navbarResponsive"
             ul class="navbar-nav text-uppercase ms-auto py-4 py-lg-0"
                 li class="nav-item"
+                    =link_to 'ホーム', root_path
+                li class="nav-item"
                     =link_to 'Login', login_path
                 li class="nav-item"
                     =link_to '新規登録', new_user_path
                 li class="nav-item"
-                    =link_to '作り方', root_path
+                    =link_to 'マイページメニュー', my_page_menus_index_path
+                li class="nav-item"
+                    =link_to '作り方', making_pancakes_simple_recipe_path
                 li class="nav-item"
                     =link_to 'カメラ起動', root_path
                 li class="nav-item"
                     =link_to 'マイレシピ', root_path
+

--- a/app/views/static_pages/top.html.slim
+++ b/app/views/static_pages/top.html.slim
@@ -4,11 +4,11 @@ header.masthead
       | PerfectPancakes
     .masthead-subheading
       div.btn.btn-primary.btn-xl.text-uppercase.m-1
-         = link_to 'ログイン', login_path
+          = link_to 'ログイン', login_path
       div.btn.btn-primary.btn-xl.text-uppercase.m-1
-         = link_to '新規登録', new_user_path
-    a.btn.btn-secondary.btn-sm.text-uppercase.mb-5
-      | ログインしないで使う
+          = link_to '新規登録', new_user_path
+    div.btn.btn-secondary.btn-sm.text-uppercase.mb-5
+          = link_to 'ログインしないで使う', making_pancakes_index_path
     .masthead-subheading
       a.btn.btn-info.btn-xl.text-uppercase.mt-5[href="#about"]
         |  ▽ 使い方

--- a/app/views/user_sessions/_form.html.slim
+++ b/app/views/user_sessions/_form.html.slim
@@ -1,14 +1,11 @@
 = form_with url: login_path, method: :post do |f|
-
-  h4.section-heading.text-uppercase
+  h4
     = f.label :email
-  h2.section-heading.text-uppercase.mb-4
+  h2.mb-4
     = f.text_field :email, class: 'form'
-
-  h4.section-heading.text-uppercase
+  h4
     = f.label :password
-  h2.section-heading.text-uppercase.mb-4
+  h2.mb-4
     = f.text_field :password, class: 'form'
-
-  h4.section-heading.text-uppercase
-     = f.submit "Login", class: 'button', class: 'btn.btn-secondary.btn-sm.text-uppercase.mb-5'
+  h4
+     = f.submit "ログイン", class: 'button', class: 'btn.btn-secondary.btn-sm.text-uppercase.mb-5'

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -1,8 +1,10 @@
-header.masthead
-    .text-center
-        h1.section-heading.text-uppercase.mb-5
-			| ログイン
-		= render 'form'
-    .masthead-subheading
-        div.btn.btn-secondary.btn-sm.text-uppercase.mb-5
-            = link_to 'Back', root_path
+body.bg-secondary
+    .container.mt-5
+        row.m-5
+        .text-center
+            h2.m-5
+		    	| ログイン
+            = render 'form'
+        .row
+            div.btn.btn-secondary.btn-sm.text-uppercase.mb-5
+                = link_to 'Back', root_path

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -6,21 +6,21 @@
         - @user.errors.full_messages.each do |message|
           li = message
 
-  h4.section-heading.text-uppercase
+  h4
     = f.label :name
-  h2.section-heading.text-uppercase.mb-4
+  h2.mb-4
     = f.text_field :name, class: 'form'
-  h4.section-heading.text-uppercase
+  h4.
     = f.label :email
-  h2.section-heading.text-uppercase.mb-4
+  h2.mb-4
     = f.text_field :email, class: 'form'
-  h4.section-heading.text-uppercase
+  h4
     = f.label :password
-  h2.section-heading.text-uppercase.mb-4
+  h2.mb-4
     = f.text_field :password, class: 'form'
-  h4.section-heading.text-uppercase
+  h4
     = f.label :password_confirmation
-  h2.section-heading.text-uppercase
+  h2
     = f.text_field :password_confirmation, class: 'form'
-  h4.section-heading.text-uppercase
-    = f.submit "create", class: 'btn.btn-secondary.btn-sm.text-uppercase.mb-5'
+  h4.mt-5
+    = f.submit "create", class: 'btn.btn-primary.btn-xl.text-uppercase.mb-5'

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,9 +1,11 @@
-header.masthead
-    .text-center
-        h1.section-heading.text-uppercase.mb-5
-            | 新規登録
-        = render 'form'
-    .masthead-subheading
+body.bg-secondary
+    .container.mt-5
+        row.m-5
+        .text-center
+            h2.m-5
+                | 新規登録
+            = render 'form'
+    .row
         div.btn.btn-secondary.btn-sm.text-uppercase.mb-5
             = link_to 'Back', root_path
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  get 'making_pancakes/simple_recipe'
+  get 'making_pancakes/index'
   get 'my_page_menus/index'
   get 'static_pages/top'
 


### PR DESCRIPTION
## やったこと
* マイページからパンケーキ作成ボタンをクリックした時の遷移先`making_pancakes`のviewとcontrollerを作成しました。
* `making_pancakes`にはtopのページとなる`index.html.slim`と簡単なパンケーキ調理方法が載っている`simple_recipe.html.slim`があります
* `index.html.slim`と`simple_recipe.html.slim`はひとまずシンプルな構造での作成をしています。
* bootstrapのクラス名の付け方が英文の意味としておかしいところがあったので全体ページの調整をしました。

