### PR TITLE
Add:動的なタイトルが出るようにしました

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+	def page_title(page_title = '')
+		base_title = 'PerfectPancakes'
+		page_title.empty? ? base_title :page_title + " | "+base_title
+	end
 end

--- a/app/views/favorite_bakings/edit.html.slim
+++ b/app/views/favorite_bakings/edit.html.slim
@@ -1,3 +1,4 @@
+- content_for(:title,'焼き加減調整')
 body.bg-secondary
   .container
     .row.mt-5

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -2,7 +2,7 @@ doctype html
 html
   head
     title
-      | PerfectPancakes
+      = page_title(yield(:title))
     <meta name="viewport" content="width=device-width, initial-scale=1">
     = csrf_meta_tags
     = csp_meta_tag

--- a/app/views/my_page_menus/index.html.slim
+++ b/app/views/my_page_menus/index.html.slim
@@ -1,3 +1,4 @@
+- content_for(:title,'マイページメニュー')
 - content_for :css do
     = stylesheet_link_tag 'my_page_menus'
 body.bg-secondary

--- a/app/views/my_page_menus/simple_recipe.html.slim
+++ b/app/views/my_page_menus/simple_recipe.html.slim
@@ -1,3 +1,4 @@
+- content_for(:title,'シンプルなレシピ')
 body.bg-secondary
     .container
         .row.pt-5

--- a/app/views/recipes/edit.html.slim
+++ b/app/views/recipes/edit.html.slim
@@ -1,3 +1,4 @@
+- content_for(:title,'レシピの編集')
 - content_for :css do
     = stylesheet_link_tag 'recipe'
 body.bg-secondary

--- a/app/views/recipes/index.html.slim
+++ b/app/views/recipes/index.html.slim
@@ -1,3 +1,4 @@
+- content_for(:title, 'マイレシピ一覧')
 body.bg-secondary
   .container.padding_100
     .row

--- a/app/views/recipes/show.html.slim
+++ b/app/views/recipes/show.html.slim
@@ -1,3 +1,4 @@
+- content_for(:title, 'レシピ詳細')
 body.bg-secondary
     .container.padding_100
         .row

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -1,3 +1,4 @@
+-content_for(:title,'ログイン')
 body.bg-secondary
     .container.mt-5
         .row

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,3 +1,4 @@
+- content_for(:title,'ユーザー編集')
 body.bg-secondary
     .container
         .row

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,3 +1,4 @@
+- content_for(:title,'新規登録')
 body.bg-secondary
     .container.padding_100
         .row

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,3 +1,4 @@
+-content_for(:title,'登録内容')
 body.bg-secondary.padding_100
   .container
     .row

--- a/app/views/webcams/index.html.slim
+++ b/app/views/webcams/index.html.slim
@@ -1,3 +1,4 @@
+- content_for(:title, 'カメラを起動')
 - content_for :css do
     = stylesheet_link_tag 'webcam'
 input type = "hidden" id = "favorite_baking" value = @favorite_baking


### PR DESCRIPTION
## やったこと

* タイトルが PerfectPancakes | 〇〇〇（個別レイアウトによって変化）と出る
* 〇〇〇はyieldで取得する個別レイアウトのタイトルで変化する
* ただしトップページはPerfectPancakesしか出さない

## どのようにして実装したか
① `application_helper.rb`に`page_title`を定義

`page_title`の内容
def page_title(page_title = '')
　base_title = 'PerfectPancakes'
　page_title.empty? ? base_title :page_title + " | "+base_title
end
* 個別レイアウトで取得するタイトルがなければ`base_title`のPerfectPancakesだけを取得
* タイトルがあればPerfectPancakes + " | "+ 動的ページのタイトル　を取得する

② `application.html.slim`に`= page_title(yield(:title))`を記載して
`page_title`に個別レイアウトのタイトルを引数として与えるようにしている

③ 1で定義した`page_title`によってタイトルが生成される
