### PR TITLE
Add:ユーザー削除機能を付けました

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: %i[ show edit update destroy ]
+  before_action :set_user, only: %i[ show edit update ]
   skip_before_action :require_login, only: [:new, :create]
 
   # GET /users/1 or /users/1.json
@@ -36,13 +36,23 @@ class UsersController < ApplicationController
     end
   end
 
+  def remove
+    @user = current_user
+  end
   # DELETE /users/1 or /users/1.json
   def destroy
-    @user.destroy
-    respond_to do |format|
-      format.html { redirect_to users_url, notice: "User was successfully destroyed." }
-      format.json { head :no_content }
+    @user = current_user
+    #削除承認のチェックボックスにチェックを入れた時、データ削除を進行する
+    if params[:user][:withdrawal_approval] == "1"
+      @user.destroy
+      respond_to do |format|
+        format.html { redirect_to root_url, flash: { success: t('.success') } }
+        format.json { head :no_content }
+      end
+    else
+      render :remove
     end
+
   end
 
   private

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -26,4 +26,9 @@ body.bg-secondary
         .form-group.text-center.pt-5
             .col-4.offset-4
                 = f.submit '更新する', class: 'btn btn-primary text-black'
-
+        .row
+            .col-4.offset-4.text-center.mt-5
+                p.text-white
+                    |退会する方は
+                    span
+                        = link_to 'こちら', remove_path

--- a/app/views/users/remove.html.slim
+++ b/app/views/users/remove.html.slim
@@ -1,0 +1,26 @@
+- content_for(:title,'退会')
+body.bg-secondary
+    .container
+        .row
+            .text-center
+                h2.m-5.text-white
+                    | 退会
+        .row
+            .col-8.offset-2.text-white
+                p 以下の注意事項をご確認頂き同意した上で、同意するにチェックを頂き、『退会する』を選択してください。
+        .row
+            .col-8.offset-2.text-danger
+                p アカウント削除を行うと、ユーザーに紐づく全データは削除されます。
+                p また、データの復元、データの移行はできません
+
+
+    = form_with model: @user, method: :delete, local: true do |f|
+        .form-group.text-ehite.text-center
+            .col-10.offset-1.text-center.text-white
+                = f.label :同意する
+            .col-10.offset-1
+                = f.check_box :withdrawal_approval
+
+        .row
+            .col-4.offset-4.text-center
+                = f.submit "退会する", class: 'btn btn-danger text-black'

--- a/config/locales/activerecord/views/ja.yml
+++ b/config/locales/activerecord/views/ja.yml
@@ -26,6 +26,8 @@ ja:
     update:
       success: '更新できました'
       fail: '更新できませんでした'
+    destroy:
+      success: '退会手続きが完了しました。'
   user_sessions:
     new:
       title: 'ログイン'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   post 'contacts/back', to: 'contacts#back', as: 'back'
 
   resources :users, only: [:create, :new, :edit, :show, :destroy, :update]
+  get 'remove' => 'users#remove', :as => :remove
+
   get 'login' => 'user_sessions#new', :as => :login
   post 'login' => "user_sessions#create"
   delete 'logout' => 'user_sessions#destroy', :as => :logout


### PR DESCRIPTION
## 削除機能について

1 ユーザー編集画面より、下部に`退会する方はこちら`のリンクをクリック
2 クリックすると退会の注意事項の書かれた、退会確認のページに遷移する
3 注意事項に問題なければチェックボックスにチェックを入れ、`退会する`をクリック
4 トップページに遷移し、ヘッダーメッセージに`退会手続きが完了しました`と出る

## 実装方法について
* 削除する前に注意事項を確認するページを挟みたい為、コントローラーにremoveアクションを追加
* `/views/users/remove.html.slim`にて確認ページを作成
* チェックボックスはmodelへの保存は必要ないため、userモデルにカラムは作成していません。

## チェックボックスにチェックがついているかの確認について
* `remove.html.slim`に記載している送信用のフォームは` = f.check_box :withdrawal_approval`としています。
* コントローラー側でボックスにチェックが入っているかの判断は
`if params[:user][:withdrawal_approval] == "1"`としています。
※` = f.check_box :withdrawal_approval`はチェックが入っていない時は0、入っている時は1を返す

初めはチェックボックスの値をfalse、tureの表記にしようと考えましたが
`= f.check_box :withdrawal_approval, as: :bollean, checked: false`
とするとチェックボックスに何も入っていない時、nillになりparamsに送られず
`if params[:user][:withdrawal_approval] `で`params[:user][:withdrawal_approval]`がnillだというエラーが出てしまいました。
