### PR TITLE
Fix:ログインしていない状態でもカメラ起動ページへの許可をしました

### DIFF
--- a/app/controllers/webcams_controller.rb
+++ b/app/controllers/webcams_controller.rb
@@ -1,4 +1,5 @@
 class WebcamsController < ApplicationController
+	skip_before_action :require_login, only: [:index]
     def index
         if current_user
           @favorite_baking = User.find(current_user.id).favorite_baking


### PR DESCRIPTION
## やったこと
sorceryのrequire_loginメソッド（ログインしているか確認するメソッド）がスキップされない設定になっていたので
```skip_before_action :require_login, only: [:index]```を加えました。
