### PR TITLE
Fix:ブラウザのコンソールエラーが出ないようにしました

### DIFF
--- a/app/views/shared/_header.slim
+++ b/app/views/shared/_header.slim
@@ -14,5 +14,3 @@ nav class="navbar navbar-expand-lg navbar-dark bg-dark"
 
 //ナビバーを読み込ませるため
 script[src="https://cdn.jsdelivr.net/npm/bootstrap@4.3.1/dist/js/bootstrap.bundle.min.js"]
-script[src="https://cdn.startbootstrap.com/sb-forms-latest.js"]
-

--- a/app/views/shared/_login_header.slim
+++ b/app/views/shared/_login_header.slim
@@ -15,5 +15,3 @@ nav class="navbar navbar-expand-lg navbar-dark bg-dark"
 
 //ナビバーを読み込ませるため
 script[src="https://cdn.jsdelivr.net/npm/bootstrap@4.3.1/dist/js/bootstrap.bundle.min.js"]
-script[src="https://cdn.startbootstrap.com/sb-forms-latest.js"]
-


### PR DESCRIPTION
## 修正前
Googleデベロッパーでコンソールを見ると全ページで、下記表示が出ている
```
sb-forms-latest.js:5 Uncaught Error: GET_ELEMENTS:  -> form[data-sb-form-api-token]
    at e (sb-forms-latest.js:5)
    at sb-forms-latest.js:5
```
## 修正後
ヘッダー部分のhtml.slimの記述でjavascriptを読み込ませているコードでエラーが出ていた
```script[src="https://cdn.startbootstrap.com/sb-forms-latest.js"]```

これはbootstrapで搭載できる、簡単に問い合わせ等のフォームを送信する機能のようですが、現在使用していなくフォームがないのでエラーが出ていた
この一文を削除してエラーが出ないようになりました。