### PR TITLE
Add:webカメラページで画像識別の返答の表示パターンを3つから5つに増やしました

### DIFF
--- a/app/javascript/packs/webcam.js
+++ b/app/javascript/packs/webcam.js
@@ -53,7 +53,7 @@ window.onload = function() {
       instructions.innerHTML = ""
 
     //googleのteachablemachineを使用して画像解析をするのでモデル先のURLを格納
-      const URL = "https://teachablemachine.withgoogle.com/models/vtT6LMR6V/";
+      const URL = "https://teachablemachine.withgoogle.com/models/w_phl0QcW/";
 
     //teachablemachineのモデルURLを読み込む
       const modelURL = URL + "model.json";
@@ -61,7 +61,6 @@ window.onload = function() {
 
     //モデルのイメージを格納する
       model = await tmImage.load(modelURL, metadataURL);
-      console.log(model);
     //フロント側に表示する結果ラベルをDOMに要素追加する
       labelContainer = document.getElementById("label-container");
     //進捗インジケータを見えなくする
@@ -78,21 +77,29 @@ window.onload = function() {
       const prediction = await model.predict(canvas);
       //数値によってラベルの結果を変更する
       //#{@user}はuserモデルのfavoriteカラム（焼き加減）の数値が入るようになっている
-        if (( prediction[0].probability.toFixed(2) * favorite_baking) >= 0.02) {
-          labelContainer.className = "mocchiri ";
-          labelContainer.innerHTML = "いまだ！！";
-        }
 
-        if (( prediction[0].probability.toFixed(2) * favorite_baking) < 0.02 && (prediction[0].probability.toFixed(2) * favorite_baking) >= 0.01) {
-          labelContainer.className = "purupuru2";
-          labelContainer.innerHTML = "もうすこし";
-        }
-
-
-        if (( prediction[0].probability.toFixed(2) * favorite_baking) < 0.01 && (prediction[0].probability.toFixed(2) * favorite_baking) >= 0) {
-            labelContainer.className = "yureru-s";
+      switch(true){
+        case prediction[0].probability.toFixed(2) * favorite_baking >= 0.4:
+          labelContainer.className = "yureru-s";
           labelContainer.innerHTML = "まだまだ";
-        }
+        break;
+        case prediction[1].probability.toFixed(2) * favorite_baking >= 0.4:
+          labelContainer.className = "yureru-s";
+          labelContainer.innerHTML = "今だ";
+        break;
+        case prediction[1].probability.toFixed(2) * favorite_baking >= 0.2:
+          labelContainer.className = "yureru-s";
+          labelContainer.innerHTML = "もう少し";
+        break;
+        case prediction[2].probability.toFixed(2) * favorite_baking > 0.2:
+          labelContainer.className = "yureru-s";
+          labelContainer.innerHTML = "Perfect";
+          break;
+        case prediction[3].probability.toFixed(2) * favorite_baking > 0.2:
+          labelContainer.className = "yureru-s";
+          labelContainer.innerHTML = "パンケーキを映してください";
+          break;
+      }
 
       window.requestAnimationFrame(loop);
       }


### PR DESCRIPTION
## やったこと
* 表示パターンを『まだまだ』、『もう少し』、『今だ』、の3つから『パンケーキを映してください』、『perfect』を追加しました。
### 『パンケーキを映してください』と出すためにやったこと
* APIのteachablemachineにパンケーキ以外が映っているものを認識させるために
キーワードに『キッチン周り』『調理器具』『料理』に該当する画像を100件づつを機械学習に追加しました。
画像取得はgoogle images downloadを利用しました。
[参考にしたサイト](https://laboratory.kazuuu.net/download-google-images-using-python/)
### 『perfect』を出すためにやったこと
* 同じようにキーワードに『パンケーキ』で取得した画像100件を学習させました。

### javascript上でやったこと
* パターンが多くなったので、コードを簡潔にするためにcaseを使用して記述をしました。
* 現状では```case prediction[1].probability.toFixed(2) * favorite_baking >= 0.4:```のように`0.4`の部分はまだ仮の数値を入れています。スマホで確認ができるようになってから数値を調整していきます。
