### PR TITLE
Fix:webcam.jsを特定ページのみで読み取りにしました

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,7 +10,6 @@ require("@rails/activestorage").start()
 require("channels")
 require('jquery')
 require('./scripts.js')
-require('./webcam.js')
 //= require jquery3
 //= require popper
 //= require bootstrap

--- a/app/views/webcams/index.html.slim
+++ b/app/views/webcams/index.html.slim
@@ -1,6 +1,7 @@
 - content_for(:title, 'カメラを起動')
 - content_for :css do
     = stylesheet_link_tag 'webcam'
+= javascript_pack_tag "webcam"
 input type = "hidden" id = "favorite_baking" value = @favorite_baking
 
 .webcam-container.bg-secondary


### PR DESCRIPTION
## 問題点
webcam.jsを全ページ読み込みにするとweb.html.slim以外のページでも要素の取得をしようとしてエラーが出てしまう

## やったこと
* webcam.jsをapplication.jsのリストから外す
* webcam.jsの読み取りをするためにwebcam.html.slimに```= javascript_pack_tag "webcam"```を記述している
