### PR TITLE
fix:Gemfile.lock & database.yml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,17 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jwt (2.3.0)
+    kaminari (0.17.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
+    letter_opener_web (1.4.1)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -149,6 +160,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     oauth (0.5.8)
     oauth2 (1.4.7)
@@ -286,6 +299,7 @@ GEM
 
 PLATFORMS
   -darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   better_errors
@@ -297,6 +311,8 @@ DEPENDENCIES
   html2slim
   jbuilder (~> 2.7)
   jquery-rails
+  kaminari
+  letter_opener_web (~> 1.0)
   listen (~> 3.2)
   mini_magick
   pg (>= 0.18, < 2.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -81,6 +81,7 @@ test:
 #
 production:
   <<: *default
-  database: PerfectPancakes_production
-  username: PerfectPancakes
-  password: <%= ENV['PERFECTPANCAKES_DATABASE_PASSWORD'] %>
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
+


### PR DESCRIPTION
## Herokuへのデプロイをするための修正
Herokuで作成したアプリケーションへpushをおこなうため、`git push heroku main`としたところエラーでpushが中断された。ターミナルの分の途中に` Failed to install gems via Bundler.`の表記があった、herokuのbundlerとローカルでのbundlerのバージョンに相違があることでpushが出来なかったようだった。
### 解決策
```bundle lock --add-platform x86_64-linux```を実行

---

```database.yml```の`production:`部分はPostgreSQLを使用する設定に変更
