### PR TITLE
Add:IOSのsafariでアドレスバーが出る画面に対応

### DIFF
--- a/app/assets/stylesheets/styles.css
+++ b/app/assets/stylesheets/styles.css
@@ -11335,6 +11335,12 @@ html {
   scroll-padding-top: 4.5rem;
   height: 100%;
 }
+@media screen and (max-width: 1125px) {
+  .html {
+    scroll-padding-top: 4.5rem;
+    height: 140%;
+  }
+}
 
 body {
   height: 100%;
@@ -11342,7 +11348,14 @@ body {
   position: relative;
   overflow-x: visible;
 }
-
+@media screen and (max-width: 1125px) {
+  body {
+    height: 140%;
+    padding-bottom: 100px;
+    position: relative;
+    overflow-x: visible;
+  }
+}
 footer{
   height:100px
 }

--- a/app/assets/stylesheets/styles.css
+++ b/app/assets/stylesheets/styles.css
@@ -11335,7 +11335,7 @@ html {
   scroll-padding-top: 4.5rem;
   height: 100%;
 }
-@media screen and (max-width: 1125px) {
+@media screen and (max-width: 1134px) {
   .html {
     scroll-padding-top: 4.5rem;
     height: 140%;
@@ -11348,7 +11348,7 @@ body {
   position: relative;
   overflow-x: visible;
 }
-@media screen and (max-width: 1125px) {
+@media screen and (max-width: 1134px) {
   body {
     height: 140%;
     padding-bottom: 100px;


### PR DESCRIPTION
## 問題
IOSのsafariでサイトを開いたところアドレスバーがあるため、bodyの下部の一部が隠れてしまった

### やった事
* スマホ画面の時には縦幅を100％から140%になるように調整
* iPhoneの6~11までのサイズで対応できるよう縦幅`1134px`までを範囲にしている
* javascriptでデバイスを識別してサイズを変更できる対応もあるようなので本来そうしたいが、リリースを少しでも早くしてスクールの方から意見を聞く時間が欲しいので、一旦ここは簡易的な対応をとります。