### PR TITLE
Add:favorite_bakingにデフォルト値を付けました

### DIFF
--- a/app/views/favorite_bakings/edit.html.slim
+++ b/app/views/favorite_bakings/edit.html.slim
@@ -15,7 +15,7 @@ body.bg-secondary
           |しっとり
     = form_with url: favorite_bakings_update_path,method: :get,local: true do |f|
       #customRange3.form-range
-        = f.range_field :w1, min: 0.7, max: 1.5, step: 0.1, value: @user.favorite_baking,class: "form-range", id: "slider1"
+        = f.range_field :w1, min: 0.7, max: 1.3, step: 0.1, value: @user.favorite_baking,class: "form-range", id: "slider1"
       .row
         .col
           = f.submit "保存", class: 'btn btn-primary m-1'

--- a/db/migrate/20220102153410_change_column_default_to_users.rb
+++ b/db/migrate/20220102153410_change_column_default_to_users.rb
@@ -1,0 +1,5 @@
+class ChangeColumnDefaultToUsers < ActiveRecord::Migration[6.0]
+  def change
+    change_column :users, :favorite_baking, :float, default: 1
+  end
+end


### PR DESCRIPTION
## 問題
usersモデルのfavorite_bakingにデフォルト値がなくユーザー新規登録時に値が0になってしまっていた
画像判定時の計算方法を以下のようにfavorite_bakingの値を掛け合わせているので0だと全て0になってしまう。
```
      case prediction[1].probability.toFixed(2) * favorite_baking >= 0.05:
        labelContainer.className = "yureru-s";
        labelContainer.innerHTML = "もう少し";
      break;
```
## 修正したこと
* favorite_bakingにデフォルト値`1`を付けるマイグレーションファイルを作成
* 焼き加減の調整を保存するページ`app/views/favorite_bakings/edit.html.slim`にて中央値が`1`になるように修正