### PR TITLE
Fix:メールのホスト情報を変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,7 +70,7 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
 
   # 本番環境でのmailerの設定
-  config.action_mailer.default_url_options = {  host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = {  :host => 'https://perfect-pancakes.herokuapp.com' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.smtp_settings = {


### PR DESCRIPTION
### 修正前
* パスワード再設定の申し込みページから送信をクリックし、送られてくるメールに書いてある再設定リンクが`http://localhost:3000/password_resets/パスワードトークン`とローカルのリンクになってしまっていた
* `config/environments/production.rb`で、ホストの設定がローカル用になっている事が原因

### 修正後
* 本番環境用のurlに変更に変更
* `https://perfect-pancakes.herokuapp.com/password_resets/パスワードトークン`のリンクが送られてくるようになった