### PR TITLE
Narrow the footer width/#85

### DIFF
--- a/app/assets/stylesheets/styles.css
+++ b/app/assets/stylesheets/styles.css
@@ -159,7 +159,7 @@ h6, .h6 {
 
 p {
   margin-top: 0;
-  margin-bottom: 1rem;
+  margin-bottom: 0;
 }
 
 abbr[title],
@@ -11344,7 +11344,7 @@ html {
 
 body {
   height: 100%;
-  padding-bottom: 100px;
+  padding-bottom: 70px;
   position: relative;
   overflow-x: visible;
 }
@@ -11356,8 +11356,8 @@ body {
     overflow-x: visible;
   }
 }
-footer{
-  height:100px
+footer {
+  height:70px
 }
 
 p {

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -25,7 +25,7 @@ html
         = render 'shared/login_header'
       = render 'shared/flash_message'
     = yield
-    footer.fixed-bottom
+    footer.fixed-bottom.bg-dark.d-flex.align-items-center
       - if current_user
         = render 'shared/login_footer'
       - else

--- a/app/views/shared/_footer.html.slim
+++ b/app/views/shared/_footer.html.slim
@@ -1,12 +1,10 @@
-footer.bg-dark
-    .container.p-2
-        .row
-            .col-4.text-center
+.container
+    .row
+        .col-4.text-center
+        .col-4.text-center
+            = link_to webcams_index_path, data: {"turbolinks" => false}
+                i.bi.bi-camera
+                br
+                p カメラを起動
+        .col-4.text-center
 
-            .col-4.text-center
-                = link_to webcams_index_path, data: {"turbolinks" => false}
-                    i.bi.bi-camera.fa-2x
-                    p カメラを起動
-            .col-4.text-center
-
- 

--- a/app/views/shared/_login_footer.html.slim
+++ b/app/views/shared/_login_footer.html.slim
@@ -1,16 +1,15 @@
-footer.bg-dark
-    .container.p-2
-        .row
-            .col-4.text-center
-                = link_to my_page_menus_index_path, data: {"turbolinks" => false}
-                    i.bi.bi-house.fa-2x
-                    p マイページ
-            .col-4.text-center
-                = link_to webcams_index_path, data: {"turbolinks" => false}
-                    i.bi.bi-camera.fa-2x
-                    p カメラを起動
-            .col-4.text-center
-                = link_to recipes_path, data: {"turbolinks" => false}
-                    i.bi.bi-book.fa-2x
-                    p マイレシピ
+.container.p-2
+    .row
+        .col-4.text-center
+            = link_to my_page_menus_index_path, data: {"turbolinks" => false}
+                i.bi.bi-house
+                p マイページ
+        .col-4.text-center
+            = link_to webcams_index_path, data: {"turbolinks" => false}
+                i.bi.bi-camera
+                p カメラを起動
+        .col-4.text-center
+            = link_to recipes_path, data: {"turbolinks" => false}
+                i.bi.bi-book
+                p マイレシピ
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,7 +70,7 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
 
   # 本番環境でのmailerの設定
-  config.action_mailer.default_url_options = {  host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = {  :host => 'https://perfect-pancakes.herokuapp.com' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.smtp_settings = {


### PR DESCRIPTION
## やったこと
### footerの不要なコードの修正とレイアウト修正
* `application.html.slim `でfooterクラスを使っているのにrenderをしている`_login_footer.html.slim `と`_footer.html.slim`にもfooteクラスを使っており重複してしまっているので`application.html.slim `だけでfooterを使用
* footerの背景を黒系にする`.bg-dar`も`application.html.slim `にまとめる
* 上下中央に配置するために`bg-dark.d-flex.align-items-center`を追加

`application.html.slim`の結果のコード
```
    footer.fixed-bottom.bg-dark.d-flex.align-items-center
      - if current_user
        = render 'shared/login_footer'
      - else
        = render 'shared/footer'
```
---
### アイコンの大きさ変更
* アイコンの大きさを2倍にするfa-2xを削除
---
### その他
* footerの高さを70pxに変更
* pの下に余白ができてしまっていたのでcssで設定してるpのmargin-bottomを0に変更