### PR TITLE
Fixed so that the bottom is not hidden/#91

### DIFF
--- a/app/views/contacts/new.html.slim
+++ b/app/views/contacts/new.html.slim
@@ -1,5 +1,5 @@
 body.bg-secondary
-    .container.pt-2
+    .container.pt-2.padding_100
         .row
         = form_with model: @contact do |f|
             .col-10.offset-1

--- a/app/views/contacts/new.html.slim
+++ b/app/views/contacts/new.html.slim
@@ -1,5 +1,5 @@
 body.bg-secondary
-    .container.pt-5
+    .container.pt-2
         .row
         = form_with model: @contact do |f|
             .col-10.offset-1
@@ -21,6 +21,6 @@ body.bg-secondary
                 .form-group
                     .badge.badge-danger.mr-2.mb-2 必須
                     = f.label :message, 'メッセージ'
-                    = f.text_area :message, size: '5x5', class: 'form-control'
+                    = f.text_area :message, size: '5x3', class: 'form-control'
             .col-10.offset-1
                     = f.submit '送信', class: 'btn btn-primary', data: {confirm: "こちらの内容で送信を致します。宜しいでしょうか？"}

--- a/app/views/my_page_menus/index.html.slim
+++ b/app/views/my_page_menus/index.html.slim
@@ -6,7 +6,7 @@ body.bg-secondary
         .row.my_page_container
             .btn-circle
                 = link_to 'カメラを起動', webcams_index_path, data: {"turbolinks" => false}
-                .btn-circle.small
+            .btn-circle.small
                     =link_to '焼き加減調整', favorite_bakings_edit_path
             .btn-circle
                 = link_to 'マイレシピ', recipes_path

--- a/app/views/my_page_menus/index.html.slim
+++ b/app/views/my_page_menus/index.html.slim
@@ -2,17 +2,13 @@
 - content_for :css do
     = stylesheet_link_tag 'my_page_menus'
 body.bg-secondary
-    .container.h-100
+    .container.padding_100
         .row.my_page_container
-            .col-md-2
-                .btn-circle
-                    = link_to 'カメラを起動', webcams_index_path, data: {"turbolinks" => false}
-            .col-md-4
+            .btn-circle
+                = link_to 'カメラを起動', webcams_index_path, data: {"turbolinks" => false}
                 .btn-circle.small
                     =link_to '焼き加減調整', favorite_bakings_edit_path
-            .col-md-2
-                .btn-circle
-                    = link_to 'マイレシピ', recipes_path
-            .col-md-4
-                .btn-circle.small
-                    = link_to '簡単なレシピ', my_page_menus_simple_recipe_path
+            .btn-circle
+                = link_to 'マイレシピ', recipes_path
+            .btn-circle.small
+                = link_to '簡単なレシピ', my_page_menus_simple_recipe_path


### PR DESCRIPTION
## 修正内容
IOSのサファリでアドレスバーが表示される事で`body`の下部が隠れてしまう事があったので
`padding_100`を`container`に付けるようにしました
`padding_100`はstyles.cssに自分で作成したクラスで`padding-bottom:100px`をつけるクラスになってます。
### マイページメニューのレイアウト修正
デバイスの横幅によって4つのボタンの配置を横に並べていました、その場合上下中央に並べるためにcontainerの高さを100%と決めていました、100%と決めてしまうとcontainerの高さがデバイスの縦幅の長さで固定されてしまい、ボタンの大きさがデバイスの画面サイズを超えてもcontainerの高さが伸びてくれませんでした。
横に並べる事にこだわりはなく縦に並べるレイアウトでもなんらおかしくはないので縦並びに固定しました。