### PR TITLE
fix: 最後の)に;をつけました。

### DIFF
--- a/app/javascript/packs/webcam.js
+++ b/app/javascript/packs/webcam.js
@@ -5,7 +5,7 @@ window.onload = function() {
     $('#video_container').hide(); //iphonでvideoの再生ボタンが表示される事象があったので非表示にしておく
     $('#result_output_container').hide(); //ユーザーに判定結果や操作案内をするコンテナ
     $('#loader').hide(); //ローディングアニメーションは最初は非表示にしておく
-  })
+  });
 
     // labelContainer: フロント側に表示する結果を格納する
       let labelContainer, model;


### PR DESCRIPTION
## 問題点
カメラ起動画面のapp/views/webcams/index.html.slimで
ページ読み込み時はボタンをいくつか非表示にしているが、非表示になっていないものがあった
### 原因と修正内容
下記のfunctionで最後の)を;で閉じていない為、修正しました。
```
  $(function() {
    $('#video_container').hide(); //iphonでvideoの再生ボタンが表示される事象があったので非表示にしておく
    $('#result_output_container').hide(); //ユーザーに判定結果や操作案内をするコンテナ
    $('#loader').hide(); //ローディングアニメーションは最初は非表示にしておく
  })
```