### PR TITLE
fix:ヘッダーメニューからカメラ起動リンクを削除

### DIFF
--- a/app/views/shared/_login_header.slim
+++ b/app/views/shared/_login_header.slim
@@ -10,8 +10,6 @@ nav class="navbar navbar-expand-lg navbar-dark bg-dark"
           =link_to 'ログイン', login_path, data: {"turbolinks" => false}
       li class="nav-item"
           =link_to '新規登録', new_user_path, data: {"turbolinks" => false}
-      li class="nav-item"
-          =link_to 'カメラ起動', webcams_index_path, data: {"turbolinks" => false}
 
 //ナビバーを読み込ませるため
 script[src="https://cdn.jsdelivr.net/npm/bootstrap@4.3.1/dist/js/bootstrap.bundle.min.js"]


### PR DESCRIPTION
## やったこと
* 現在のレイアウトではフッターにカメラ起動へのリンクがあるので、ヘッダーメニューからは削除しました。
