### PR TITLE
Add:使い方動画を設置

### DIFF
--- a/app/assets/stylesheets/styles.css
+++ b/app/assets/stylesheets/styles.css
@@ -11353,7 +11353,7 @@ p {
 }
 
 .page-section {
-  padding-bottom: 10rem;
+  padding-bottom: 1rem;
 }
 .page-section h2.section-heading, .page-section .section-heading.h2 {
   font-size: 2.5rem;

--- a/app/views/static_pages/top.html.slim
+++ b/app/views/static_pages/top.html.slim
@@ -61,9 +61,17 @@ section#about.page-section
           .timeline-body
             p.text-muted
               | This app will tell you the timing!
+.container.p-3
+  .row.text-center
+    h2 使い方動画
+  .row
+    .col-md-4
+    .col-md-4
+      = video_tag("/videos/How_to_use.mp4", controls: true, autobuffer: true, muted: :true, class: 'w-100')
+
 
 .page-section.bg-light
-  .container.pt-5
+  .container.pt-5.padding_100
     .row.align-items-center
       .col-lg-12.text-center
         | Copyright © Your Website 2021


### PR DESCRIPTION
## やったこと

* カメラ起動ページの使い方を説明する動画を設置
* スタートを押してから、焼き上がるまでの一連の流れを説明

### レイアウトの修正
* 以下の位置に10remの余白ができてしまうので1remになるよう`styles.css`を修正しました。
---
`app/views/static_pages/top.html.slim `
```          .timeline-body
            p.text-muted
              | This app will tell you the timing!

//この間にpadding-bottom: 10remの余白ができてしまう。

.container.p-3
  .row.text-center
    h2 使い方動画
```
---