### PR TITLE
fix:判定数値を見直しました

### DIFF
--- a/app/javascript/packs/webcam.js
+++ b/app/javascript/packs/webcam.js
@@ -102,7 +102,7 @@ window.onload = function() {
     //数値によってラベルの結果を変更する
     //#{@user}はuserモデルのfavoriteカラム（焼き加減）の数値が入るようになっている
     switch(true){
-      case prediction[0].probability.toFixed(2) >= 0.5:
+      case prediction[0].probability.toFixed(2) * favorite_baking >= 0.5:
         labelContainer.className = "yureru-s";
         labelContainer.innerHTML = "まだまだ";
         if (baking_status == "not_baked"){
@@ -110,7 +110,7 @@ window.onload = function() {
           baking_status = "start_baking";
         }
       break;
-      case prediction[1].probability.toFixed(2) >= 0.8:
+      case prediction[1].probability.toFixed(2) * favorite_baking >= 0.8:
         labelContainer.className = "yureru-s";
         labelContainer.innerHTML = "今だ";
         if (baking_status =="start_baking"){
@@ -119,15 +119,15 @@ window.onload = function() {
           baking_status = "baking_completed"
         }
       break;
-      case prediction[1].probability.toFixed(2) * favorite_baking >= 0.5:
+      case prediction[1].probability.toFixed(2) * favorite_baking >= 0.4:
         labelContainer.className = "yureru-s";
         labelContainer.innerHTML = "もう少し";
       break;
-      case prediction[2].probability.toFixed(2) * favorite_baking >= 0.7:
+      case prediction[2].probability.toFixed(2) >= 0.7:
         labelContainer.className = "yureru-s";
         labelContainer.innerHTML = "PerfectPancakes!!";
         break;
-      case prediction[3].probability.toFixed(2) * favorite_baking >= 0.8:
+      case prediction[3].probability.toFixed(2) >= 0.8:
         labelContainer.className = "yureru-s";
         labelContainer.innerHTML = "パンケーキを映してください"
         break;

--- a/app/views/favorite_bakings/edit.html.slim
+++ b/app/views/favorite_bakings/edit.html.slim
@@ -15,7 +15,7 @@ body.bg-secondary
           |しっとり
     = form_with url: favorite_bakings_update_path,method: :get,local: true do |f|
       #customRange3.form-range
-        = f.range_field :w1, min: 0.7, max: 1.3, step: 0.1, value: @user.favorite_baking,class: "form-range", id: "slider1"
+        = f.range_field :w1, min: 0.9, max: 1.1, step: 0.05, value: @user.favorite_baking,class: "form-range", id: "slider1"
       .row
         .col
           = f.submit "保存", class: 'btn btn-primary m-1'


### PR DESCRIPTION
## やったこと

* 調節機能のための変数`favorite_baking`の記載場所が正しくなかったので修正しました。
* 『今だ』の判定条件が0.8（80%）以上となっており、`favorite_baking`が最低値0.7になってしまうと
最大が70%となり、判定がされなくなってしまうので、`favorite_baking`の最大値は0.9となるようにしました。
