### PR TITLE
fix:videoのトリミングを少し拡大してcanvasに描写しました

### DIFF
--- a/app/assets/stylesheets/webcam.scss
+++ b/app/assets/stylesheets/webcam.scss
@@ -3,7 +3,7 @@
     position:absolute;
   }
 
-  video {
+  canvas {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -65,7 +65,15 @@
 
   .transparent-img {
     opacity:0;
-    width: 0px;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    margin: auto;
+    object-fit: cover;
   }
 
   .start {

--- a/app/javascript/packs/webcam.js
+++ b/app/javascript/packs/webcam.js
@@ -96,8 +96,21 @@ window.onload = function() {
   //カメラ画像からgoogleのteachablemachineのモデルより近い画像がどれか判定をしていく
   async function predict(){
   //canvasに静止画を格納する
-    var canvas =document.getElementById("canvas")
-    canvas.getContext("2d").drawImage(video, 0, 0, 200, 200)
+    var canvas =document.getElementById("canvas");
+    //videoの横縦幅とアスペクト比を取得する（サイズによってcanvasへのトリミングを変えるため）
+    var videoWidth = video.videoWidth;//横幅を取得
+    var videoHeight = video.videoHeight;//縦幅を取得
+    var videoRate = videoWidth / videoHeight;//アスペクト比を取得
+    var videoPos = 0;
+
+    if(videoRate >= 1){ //画像が横長のとき
+      videoPos = (200 - (200 * videoRate)) / 2; //横方向の画像位置を計算
+      canvas.getContext("2d").drawImage(video, videoPos, 0, 200 * videoRate, 200); //Canvasに幅を基準に画像を描画
+    }else{ //画像が縦長のとき
+      videoPos = (200 - (200 / videoRate)) / 2; //縦方向の画像位置を計算
+      canvas.getContext("2d").drawImage(video, 0, videoPos, 200, 200 / videoRate); //Canvasに高さを基準に画像を描画
+    }
+
     const prediction = await model.predict(canvas);
     //数値によってラベルの結果を変更する
     //#{@user}はuserモデルのfavoriteカラム（焼き加減）の数値が入るようになっている
@@ -180,4 +193,3 @@ window.onload = function() {
   });
 
 }
-

--- a/app/views/webcams/index.html.slim
+++ b/app/views/webcams/index.html.slim
@@ -18,16 +18,17 @@ body.bg-secondary
     .start
       .btn.btn-success.btn-lg[id="init_btn"]
         |スタート
-
+  
   .container
     .video_container#video_container
-      video#video[autoplay playsinline]
+      video#video.transparent-img[autoplay playsinline]
+      canvas#canvas[width="150px" height="150px"]
     .result_output_container#result_output_container
       .label
         #label-container
       .second_step_box
         #baking_time_result.pb-2
-      canvas#canvas.transparent-img
+      
     .second_step_start
       .btn.btn-success.btn-lg[id="second_baking_button"]
         |スタート


### PR DESCRIPTION
## 変更した仕様
webカメラの映像を出しているvideタグを前面に表示していましたが
画像解析のために切り出しているcanvasを前面に表示するようにしました。
`video`と`canvas`のトリミングに微妙な差異があり、実際に画像解析に使用しているのは`canvas`の方なのでこちらが表示している方がいいと思ったためです。

## やったこと

* `canvas`に前面に出す為のクラスを付与
* `video`は表示されないように透明になるクラス`.transparent-imgを付与
*  javascriptではvideoのサイズ＆アスペクト比によって`drawImage`で切り取る数値を変更できるようにしました。
* htmlでは```canvas#canvas[width="150px" height="150px"]```として150pxの正方形にしているのに対して、javascriptでの`drawImage`での切り取りは200pxの正方形となっている為、`canvas`は200pxを150pxで切り取る形になります。
これにより、画像を少し拡大して描写する方法をとっています。
