### PR TITLE
fix:モデルの更新&カメラ映像をさらに拡大

### DIFF
--- a/app/javascript/packs/webcam.js
+++ b/app/javascript/packs/webcam.js
@@ -49,7 +49,7 @@ window.addEventListener = function() {
       $('#loader').removeClass('hide'); //ローディングアニメーションを表示
 
     //googleのteachablemachineを使用して画像解析をするのでモデル先のURLを格納
-      const URL = "https://teachablemachine.withgoogle.com/models/wL8WLzC5R/";
+      const URL = ""https://teachablemachine.withgoogle.com/models/wL8WLzC5R/;
 
     //teachablemachineのモデルURLを読み込む
       const modelURL = URL + "model.json";

--- a/app/javascript/packs/webcam.js
+++ b/app/javascript/packs/webcam.js
@@ -49,7 +49,7 @@ window.addEventListener = function() {
       $('#loader').removeClass('hide'); //ローディングアニメーションを表示
 
     //googleのteachablemachineを使用して画像解析をするのでモデル先のURLを格納
-      const URL = ""https://teachablemachine.withgoogle.com/models/wL8WLzC5R/;
+      const URL = "https://teachablemachine.withgoogle.com/models/wL8WLzC5R/";
 
     //teachablemachineのモデルURLを読み込む
       const modelURL = URL + "model.json";

--- a/app/views/webcams/index.html.slim
+++ b/app/views/webcams/index.html.slim
@@ -15,7 +15,7 @@ body.bg-secondary
       .col
         .video_container#video_container
           video#video.hide[autoplay playsinline]
-          canvas#canvas[width="150px" height="150px"]
+          canvas#canvas[width="120px" height="120px"]
           = image_tag 'point_img.png', id: 'point_img'
           = image_tag 'first_baking_completed_img.png', class: 'hide', id: 'first_baking_completed_img'
           = image_tag 'completed_img.png', class:"hide gaming",id: 'completed_img'


### PR DESCRIPTION
## やったこと

* パンケーキの解析用画像を更新し、更新したモデルを反映させました。
まだまだ： 256枚
今だ： 344枚
* canvasのサイズを120pxに小さくすることで、javascriptでおこなっているwebカメラの映像をcanvasに描写する処理のサイズが小さくなり、カメラ映像をトリミングします。
できるだけフライパンとパンケーキ以外を映さないようにしたいためです。
