### PR TITLE
fix:スタートボタンの起動をjqueryではなくしました。

### DIFF
--- a/app/javascript/packs/webcam.js
+++ b/app/javascript/packs/webcam.js
@@ -6,19 +6,20 @@ window.addEventListener = function() {
   // 焼き加減の数値を格納
   var favorite_baking = document.getElementById("favorite_baking");
   var favorite_baking = favorite_baking.getAttribute('value');
-  var URL
-
+  var URL;
+  var start_btn =document.getElementById('start_btn');
+  var thick_size_start_btn =document.getElementById('thick_size_start_btn');
       //パンケーキの厚さによって解析用画像モデルを変更するので、二つのスタートボタンを用意し分岐させる
-      $('#start_btn').on('click', function(){
+      start_btn.onclick = function(){
       //googleのteachablemachineを使用して画像解析をするのでモデル先のURLを格納
         URL = "https://teachablemachine.withgoogle.com/models/gXEpLx0KS/";//パンケーキの厚みが通常の画像を格納したモデル
         init();
-      });
-      $('#thick_size_start_btn').on('click', function(){
+      }
+      thick_size_start_btn.onclick = function(){
         //googleのteachablemachineを使用して画像解析をするのでモデル先のURLを格納
         URL = "https://teachablemachine.withgoogle.com/models/G3RgTX00-/";//パンケーキが厚めの画像を格納したモデル
         init();
-      });
+      }
 
       async function init() {
         $("#point_img").addClass('hide');//initが押されたらうまく焼くポイントの画像を非表示にする


### PR DESCRIPTION
前回、カメラ起動ページからパンケーキの厚さによって解析画像を変更できるよう（解析の精度を上げるために）
通常のボタンを押すと通常の厚みで学習したモデル
厚めのボタンを押すと厚めで学習したモデル
で画像解析をするようにしていたが、ボタンを押した時に作動する部分をjQueryで動かしていたが
どうやらjQueryは動作が重く多用してはいけない事が分かった。

### 問題点
* カメラの表示画像(canavsにdrawImageで切り取っている画像)が以前より滑らかではなく重くなっている感じがする
* スマホで確認した時に、ローディングが終わってもカメラ画面が映らない、もしくは数秒経ってから表示される

### 改善点
* javascriptの記述方法に戻す。
### その他
* 一旦全てコードの見直しをしたいと思うので新たにIssuesを立てて修正します。
