### PR TITLE
fix:ログイン画面への遷移のパスを修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,6 @@ class ApplicationController < ActionController::Base
   private
 
   def not_authenticated
-    redirect_to login_path
+    redirect_to  new_user_sessions_path
   end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -29,7 +29,7 @@ class PasswordResetsController < ApplicationController
 
     @user.password_confirmation = params[:user][:password_confirmation]
     if @user.change_password(params[:user][:password])
-      redirect_to login_path, flash: { success: t('.success') }
+      redirect_to new_user_sessions_path, flash: { success: t('.success') }
     else
       render action: 'edit'
     end


### PR DESCRIPTION
## やったこと
pathの設定で修正が漏れていた部分があったので以下２点修正

* ログイン状態ではない時にユーザー機能を使おうとした時に遷移するログイン画面へのパス
* パスワード再設定後に遷移するログイン画面へのパス
